### PR TITLE
Add auto install example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@
 
 ## 🌟 Projects
 
-ToDo
+### Auto Installer Example
+
+Dieses Repository enthält ein Beispielskript, das benötigte Python-Pakete automatisch installiert und anschließend einen zufälligen Katzenfakt ausgibt. Das Skript befindet sich in `auto_installer_example.py`.
+
+Führe es mit:
+
+```bash
+python auto_installer_example.py
+```
+
+Falls `requests` oder `rich` nicht vorhanden sind, installiert das Skript diese automatisch.
 
 ---
 

--- a/auto_installer_example.py
+++ b/auto_installer_example.py
@@ -1,0 +1,42 @@
+import subprocess
+import sys
+
+REQUIRED_PACKAGES = [
+    "requests",
+    "rich",
+]
+
+def ensure_packages(packages):
+    """Ensure that required packages are installed."""
+    for pkg in packages:
+        try:
+            __import__(pkg)
+        except ImportError:
+            print(f"Installing {pkg}...")
+            subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+
+
+def fetch_cat_fact():
+    """Fetch a random cat fact from an API."""
+    import requests
+    response = requests.get("https://catfact.ninja/fact", timeout=5)
+    response.raise_for_status()
+    return response.json().get("fact", "No fact found.")
+
+
+def main():
+    ensure_packages(REQUIRED_PACKAGES)
+    from rich import print
+    from rich.console import Console
+
+    console = Console()
+    console.rule("Cat Fact")
+    try:
+        fact = fetch_cat_fact()
+        console.print(f"[bold green]{fact}[/bold green]")
+    except Exception as exc:
+        console.print(f"[red]Failed to fetch cat fact: {exc}[/red]")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python example with auto-installing dependencies
- document the script in README

## Testing
- `python -m py_compile auto_installer_example.py`
- `python auto_installer_example.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6870e4f3bec8832790be64dc39756dd9