### PR TITLE
Add simple Flask key auth system

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,22 @@ ToDo
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Profile-blue?style=for-the-badge&logo=linkedin)](https://www.linkedin.com/in/your-profile/)
 [![Twitter](https://img.shields.io/badge/Twitter-Profile-blue?style=for-the-badge&logo=twitter)](https://twitter.com/your-profile)
 [![Website](https://img.shields.io/badge/Website-Portfolio-green?style=for-the-badge)](https://your-website.com)
+
+---
+
+## KeyAuth System
+
+This repository now includes a simple self-hosted license key system built with Flask.
+
+### Setup
+
+1. Install dependencies:
+   ```bash
+   pip install Flask Werkzeug
+   ```
+2. Run the server:
+   ```bash
+   python keyauth/server.py
+   ```
+3. Visit `http://localhost:5000/login` and login with the default credentials `admin` / `admin`.
+4. Generate or deactivate keys from the admin panel. Use the `/api/verify` endpoint to validate keys from your application.

--- a/keyauth/server.py
+++ b/keyauth/server.py
@@ -1,0 +1,130 @@
+from flask import Flask, request, redirect, render_template, session, url_for
+import sqlite3
+from werkzeug.security import generate_password_hash, check_password_hash
+from functools import wraps
+
+app = Flask(__name__)
+app.secret_key = 'change_me'
+DATABASE = 'keyauth.db'
+
+
+def get_db():
+    conn = sqlite3.connect(DATABASE)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = get_db()
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            password TEXT NOT NULL
+        )
+        """
+    )
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS keys (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            key TEXT UNIQUE NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+@app.before_first_request
+def setup():
+    init_db()
+    # Create default admin if not exists
+    conn = get_db()
+    c = conn.cursor()
+    c.execute("SELECT * FROM users WHERE username = ?", ("admin",))
+    if c.fetchone() is None:
+        c.execute(
+            "INSERT INTO users (username, password) VALUES (?, ?)",
+            ("admin", generate_password_hash("admin")),
+        )
+        conn.commit()
+    conn.close()
+
+
+def login_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if 'user_id' not in session:
+            return redirect(url_for('login'))
+        return f(*args, **kwargs)
+    return decorated_function
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        conn = get_db()
+        c = conn.cursor()
+        c.execute("SELECT * FROM users WHERE username = ?", (username,))
+        user = c.fetchone()
+        conn.close()
+        if user and check_password_hash(user['password'], password):
+            session['user_id'] = user['id']
+            return redirect(url_for('admin'))
+        return render_template('login.html', error='Invalid credentials')
+    return render_template('login.html')
+
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('login'))
+
+
+@app.route('/admin', methods=['GET', 'POST'])
+@login_required
+def admin():
+    conn = get_db()
+    c = conn.cursor()
+    if request.method == 'POST':
+        new_key = request.form.get('new_key')
+        if new_key:
+            try:
+                c.execute("INSERT INTO keys (key) VALUES (?)", (new_key,))
+                conn.commit()
+            except sqlite3.IntegrityError:
+                pass
+        for key_id in request.form.getlist('deactivate'):
+            c.execute("UPDATE keys SET active=0 WHERE id=?", (key_id,))
+            conn.commit()
+    c.execute("SELECT * FROM keys")
+    keys = c.fetchall()
+    conn.close()
+    return render_template('admin.html', keys=keys)
+
+
+@app.route('/api/verify', methods=['POST'])
+def verify():
+    data = request.get_json() or {}
+    key = data.get('key')
+    if not key:
+        return {"success": False, "message": "No key provided"}, 400
+    conn = get_db()
+    c = conn.cursor()
+    c.execute("SELECT * FROM keys WHERE key=? AND active=1", (key,))
+    row = c.fetchone()
+    conn.close()
+    if row:
+        return {"success": True}
+    return {"success": False, "message": "Invalid key"}, 403
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/keyauth/templates/admin.html
+++ b/keyauth/templates/admin.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Panel</title>
+</head>
+<body>
+  <h2>Key Management</h2>
+  <p><a href="{{ url_for('logout') }}">Logout</a></p>
+  <form method="post">
+    <input type="text" name="new_key" placeholder="New Key">
+    <button type="submit">Add Key</button>
+    <h3>Existing Keys</h3>
+    <ul>
+      {% for key in keys %}
+        <li>
+          {{ key['key'] }} - {% if key['active'] %}active{% else %}inactive{% endif %}
+          {% if key['active'] %}
+          <button name="deactivate" value="{{ key['id'] }}">Deactivate</button>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </form>
+</body>
+</html>

--- a/keyauth/templates/login.html
+++ b/keyauth/templates/login.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+</head>
+<body>
+  <h2>Admin Login</h2>
+  {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+  <form method="post">
+    <input type="text" name="username" placeholder="Username" required><br>
+    <input type="password" name="password" placeholder="Password" required><br>
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Werkzeug


### PR DESCRIPTION
## Summary
- implement a small self‑hosted key authentication server
- add simple admin panel templates
- document setup instructions

## Testing
- `python3 -m py_compile keyauth/server.py`
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687111cca1a883279a23f3bb40c920f7